### PR TITLE
fix: react-navigation warning

### DIFF
--- a/src/screens/ProfileScreen/ProfileScreen.js
+++ b/src/screens/ProfileScreen/ProfileScreen.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { object } from 'prop-types';
 import { View } from 'react-native';
 
@@ -8,7 +8,9 @@ import SignOut from 'components/SignOut';
 import styles from './ProfileScreen.styles';
 
 const ProfileScreen = ({ navigation }) => {
-  navigation.setOptions({ title: strings.PROFILE_SCREEN.title });
+  useEffect(() => {
+    navigation.setOptions({ title: strings.PROFILE_SCREEN.title });
+  }, [navigation]);
 
   return (
     <View style={styles.container} testID={PROFILE_SCREEN}>


### PR DESCRIPTION
### Description:
This PR wraps the `navigation.setOptions` call in the `ProfileScreen` inside a `useEffect` since there was no need to be calling it every time the component rerenders and was throwing a warning as well.

---

#### Tasks:

- [x] Tested on iOS
- [x] Tested on Android
