### PR TITLE
fix: background notifications on android

### DIFF
--- a/src/utils/configureNotifications.js
+++ b/src/utils/configureNotifications.js
@@ -40,8 +40,8 @@ export const handleIosInitialNotification = async () => {
 export const handleAndroidPushNotification = notification => {
   if (IS_ANDROID) {
     const { foreground, userInteraction } = notification;
-    if (foreground && userInteraction) {
-      handleNotifications(notification.data);
+    if (userInteraction) {
+      handleNotifications(foreground ? notification.data : notification);
     }
   }
 };


### PR DESCRIPTION
#### Trello board reference:

- [En android al tener la app cerrada recibo la push notification de comunicado al apretar en la push no lleva al detalle del comunicado.](https://trello.com/c/gT4QTSbV/86-en-android-al-tener-la-app-cerrada-recibo-la-push-notification-de-comunicado-al-apretar-en-la-push-no-lleva-al-detalle-del-comun)

---

### Description:

La data de las notificaciones en android vienen diferente si es del background, este PR arregla ese caso.

---

#### Tasks:

- [ ] Tested on iOS
- [x] Tested on Android
- [ ] Tested on a small device