### PR TITLE
fix: set navigation options

### DIFF
--- a/src/constants/navigationOptions.js
+++ b/src/constants/navigationOptions.js
@@ -16,4 +16,6 @@ export const HEADER_OPTIONS = {
   headerTitleStyle,
   headerBackTitle: strings.NAVIGATION.back,
   headerTintColor: PRIMARY,
+  headerLeft: null,
+  headerRight: null,
 };

--- a/src/screens/MainScreen/MainScreen.navigationOptions.js
+++ b/src/screens/MainScreen/MainScreen.navigationOptions.js
@@ -1,5 +1,9 @@
 import strings from 'locale';
+import { HEADER_OPTIONS } from 'constants/navigationOptions';
 
-const navigationOptions = { title: strings.MAIN_SCREEN.title };
+const navigationOptions = {
+  ...HEADER_OPTIONS,
+  title: strings.MAIN_SCREEN.title,
+};
 
 export default navigationOptions;

--- a/src/screens/ProfileScreen/ProfileScreen.navigationOptions.js
+++ b/src/screens/ProfileScreen/ProfileScreen.navigationOptions.js
@@ -1,20 +1,20 @@
 import React from 'react';
 
 import { SECONDARY, WHITE } from 'constants/colors';
-import { headerStyle } from 'constants/navigationOptions';
-
+import { headerStyle, headerTitleStyle, HEADER_OPTIONS } from 'constants/navigationOptions';
 import strings from 'locale';
-import textStyles from 'components/Text/Text.styles';
+
 import { SignOut } from 'components';
 
 const navigationOptions = {
+  ...HEADER_OPTIONS,
   title: strings.PROFILE_SCREEN.title,
   headerStyle: {
     ...headerStyle,
     backgroundColor: SECONDARY,
   },
   headerTitleStyle: {
-    ...textStyles.H1,
+    ...headerTitleStyle,
     color: WHITE,
   },
   headerRight: () => <SignOut />,


### PR DESCRIPTION
#### Trello board reference:

- [La navbar cambia de color en el feed si se fue a novedades](https://trello.com/c/hlgRMQVV/92-la-navbar-cambia-de-color-en-el-feed-si-se-fue-a-novedades)

---

### Description:

El header pasó de ser propio de cada tab a ser compartido, el profile estaba seteando unas navigation options que la MainScreen no entonces al ir al profile y volver al feed, esos valores seteados por el feed no se sobre escrbian.

Ahora todos los navigationOptions tienen como base `HEADER_OPTIONS` que setea por defecto todos los atributos que setea cualquier otro navigationOptions para evitar este problema.

---

#### Tasks:

- [x] Tested on iOS
- [ ] Tested on Android
- [ ] Tested on a small device
