### PR TITLE
feat: add refresh on focus to feed

### DIFF
--- a/src/screens/MainScreen/FeedList/FeedList.js
+++ b/src/screens/MainScreen/FeedList/FeedList.js
@@ -1,4 +1,5 @@
-import React, { useCallback, useEffect } from 'react';
+import React, { useCallback } from 'react';
+import { func } from 'prop-types';
 import { FlatList, View } from 'react-native';
 import { useDispatch, useSelector, shallowEqual } from 'react-redux';
 import { LOADING, SUCCESS, useStatus } from '@rootstrap/redux-tools';
@@ -12,16 +13,8 @@ import FeedCard from './FeedCard';
 
 import styles from './FeedList.styles';
 
-const FeedList = () => {
+const FeedList = ({ handleRefresh }) => {
   const dispatch = useDispatch();
-
-  const handleRefresh = useCallback(() => {
-    dispatch(getFeed({ shouldReplace: true }));
-  }, [dispatch]);
-
-  useEffect(() => {
-    handleRefresh();
-  }, [handleRefresh]);
 
   const { status, error } = useStatus(getFeed);
 
@@ -58,6 +51,10 @@ const FeedList = () => {
       }
     />
   );
+};
+
+FeedList.propTypes = {
+  handleRefresh: func.isRequired,
 };
 
 export default FeedList;

--- a/src/screens/MainScreen/MainScreen.js
+++ b/src/screens/MainScreen/MainScreen.js
@@ -1,6 +1,9 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import { View } from 'react-native';
+import { useFocusEffect } from '@react-navigation/native';
+import { useDispatch } from 'react-redux';
 
+import { getFeed } from 'actions/feedActions';
 import { MAIN_SCREEN } from 'constants/screens';
 import useNotifications from 'hooks/useNotifications';
 
@@ -10,9 +13,20 @@ import styles from './MainScreen.styles';
 
 const MainScreen = () => {
   useNotifications();
+
+  const dispatch = useDispatch();
+
+  const handleRefresh = useCallback(() => {
+    dispatch(getFeed({ shouldReplace: true }));
+  }, [dispatch]);
+
+  useFocusEffect(() => {
+    handleRefresh();
+  }, [handleRefresh]);
+
   return (
     <View style={styles.container} testID={MAIN_SCREEN}>
-      <FeedList />
+      <FeedList handleRefresh={handleRefresh} />
     </View>
   );
 };


### PR DESCRIPTION
#### Trello board reference:

- [Agregar refresh on focus al feed](https://trello.com/c/YIJYN5l1/94-agregar-refresh-on-focus-al-feed)

---

### Description:
Agregar refresh on focus al feed asi cuando un usuario va a otra tab o pantalla y vuelve, se le actualiza el feed.

---

#### Tasks:

- [x] Tested on iOS
- [ ] Tested on Android
- [ ] Tested on a small device
