### PR TITLE
fix: add flexShrink 1 to 1o1 items.

### DIFF
--- a/src/components/BulletItem/BulletItem.styles.js
+++ b/src/components/BulletItem/BulletItem.styles.js
@@ -13,6 +13,7 @@ const styles = StyleSheet.create({
   },
   innerContainer: {
     flexDirection: 'row',
+    flexShrink: 1,
   },
   bullet: {
     width: 16,


### PR DESCRIPTION
#### Trello board reference:

---

### Description:

fix: add flexShrink 1 to 1o1 items.

---

#### Notes:

-

---

#### Tasks:

- [x] Tested on iOS
- [ ] Tested on Android
- [ ] Tested on a small device

### Preview:

**Before**

![Screen Shot 2020-11-08 at 15 47 28](https://user-images.githubusercontent.com/58480913/98482119-db8ef400-21dd-11eb-8ec5-62a70628c8d8.png)

**After** 

![Screen Shot 2020-11-08 at 16 14 56](https://user-images.githubusercontent.com/58480913/98482102-bef2bc00-21dd-11eb-81ba-259dfa33c2ff.png)

